### PR TITLE
Fix for Freestyle projects not parsing variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/neoload/integration/NeoBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/neoload/integration/NeoBuildAction.java
@@ -323,13 +323,11 @@ public class NeoBuildAction extends Builder implements SimpleBuildStep, NeoLoadP
      * @throws InterruptedException the interrupted exception
      */
     @Override
-    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException {
-
-        if (arePasswordsSafe()) {
-
-            final StringBuilder sb = prepareCommandLine(launcher, null, false);
+    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
+    	  if (arePasswordsSafe()) {
+        	final EnvVars env = build.getEnvironment(listener);
             build.addAction(new NeoResultsAction(build, getXMLReportArtifactPath(), getHTMLReportArtifactPath()));
-            return runTheCommand(sb.toString(), build, launcher, listener);
+            return runTheCommand(env.expand(prepareCommandLine(launcher, null, false).toString()), build, launcher, listener);
 
         } else {
             listener.getLogger().println("\nWARNING: a non-ciphered password has been detected. Please follow the procedure below:" );


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-66669
When variables are used inside step "execute a neoload scenario", jenkins is not expanding variables.
I am using unix controller and win agent.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
